### PR TITLE
Support baseUrl in script config file

### DIFF
--- a/scripts/config.toml
+++ b/scripts/config.toml
@@ -3,3 +3,7 @@ state = "closed"
 
 # If the following labels is present, the issue will not be published
 excludedLabels = ["do-not-publish"]
+
+# In order to use Octokit with GitHub Enterprise, set the baseUrl option.
+# See: https://octokit.github.io/rest.js/v19#usage
+baseUrl = "https://api.github.com"

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -48,10 +48,13 @@ const GITHUB_REPOSITORY: string = Deno.env.get("GITHUB_REPOSITORY")!;
 
 const [owner, repo] = GITHUB_REPOSITORY.split("/");
 
-const octokit = new Octokit({ auth: GITHUB_TOKEN });
-
 // Read config toml file
 const config = await readConfigFile(CONFIG_FILE);
+
+const octokit = new Octokit({
+  auth: GITHUB_TOKEN,
+  baseUrl: String(config.baseUrl),
+});
 
 // Iterate over all issues
 const iterator = octokit.paginate.iterator(


### PR DESCRIPTION
Allow users to customize `baseUrl` in config file, so it can be used in GHE.